### PR TITLE
Updated package version minimums.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ boto3==1.10.37
 botocore==1.13.37
 click==7.0
 docutils==0.15.2
-flask==1.1.1
+flask>=1.1.1
 itsdangerous==1.1.0
 jinja2==2.10.3
 jmespath==0.9.4
@@ -12,4 +12,4 @@ python-dateutil==2.8.0 ; python_version >= '2.7'
 s3transfer==0.2.1
 six==1.13.0
 urllib3==1.25.7 ; python_version >= '3.4'
-werkzeug==0.16.0
+werkzeug>=0.16.0


### PR DESCRIPTION
Updated both the base flask and the werkzeug packages to allow for newer versions to avoid installation warnings. Merge needs to be done on a separate branch for v0.3.2c release. Not to master branch.